### PR TITLE
Add advanced STRETCH tasks

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -96,6 +96,8 @@ async def health_check():
         test_client.list_models()
     except Exception as e:
         message = f"Ollama not accessible: {str(e)}"
+    else:
+        ollama_accessible = True
 
     return HealthResponse(
         status="healthy" if ollama_accessible else "degraded",

--- a/workshop/presentation/slides.md
+++ b/workshop/presentation/slides.md
@@ -1,7 +1,7 @@
 ---
 author: Redis Team Sofia
 title: Redis AI Workshop
-date: 19 Feb 2026
+date: 14 May 2026
 ---
 
 ## What are we going to do today?
@@ -188,6 +188,14 @@ we encourage exploration, asking questions, pair programming.
 - introducing LangCache
 - ./workshop/session-3/README.md
 - show me the code
+
+---
+
+### Stretch goal / homework - use AI to implement stretch tasks
+
+- Inspect READMEs for sessions 1 and 2
+- Implement stretch tasks using agentic AI
+- Any LLM will work
 
 ---
 

--- a/workshop/session-1/README.md
+++ b/workshop/session-1/README.md
@@ -52,3 +52,110 @@ curl -X POST http://localhost:8000/api/v1/ask \
   -H "Content-Type: application/json" \
   -d '{"question": "What is the capital of France?"}'
 ```
+
+---
+
+## STRETCH TASK: modern AISHE architecture
+
+Today, AISHE always requests 3 Wikipedia articles before Ollama summarizes them and responds.
+
+Modern AI agents have access to tools. If an agent decides it needs extra information,
+it calls an MCP server on its own. The information is fed back into the LLM in a loop.
+
+The goal of this task is to adjust AISHE's server implementation to support tool-calling.
+Pass Wikipedia tools to Ollama and let it decide what info it fetches via the Wikipedia MCP.
+
+You may find AISHE's server implementation inside [/src/](/src/).
+
+```
+         ┌─────────────┐
+         │    User     │
+         │  question   │
+         └──────┬──────┘
+                │
+                ▼
+    ┌───────────────────────┐
+    │       AISHE           │
+    │  (agent / server)     │◀──────────────┐
+    └───────────┬───────────┘               │
+                │                           │
+                │  prompt + available       │  tool result
+                │  tools (wiki search,      │  (article text)
+                │  wiki fetch, ...)         │
+                ▼                           │
+        ┌───────────────┐                   │
+        │    Ollama     │                   │
+        │     LLM       │                   │
+        └───────┬───────┘                   │
+                │                           │
+     ┌──────────┴──────────┐                │
+     │                     │                │
+  has enough           needs more           │
+  info?                info? (tool call)    │
+     │                     │                │
+     ▼                     ▼                │
+┌─────────────┐     ┌─────────────┐         │
+│   Final     │     │ Wikipedia   │         │
+│   answer    │     │    MCP      │         │
+│  + sources  │     │   server    │         │
+└──────┬──────┘     └──────┬──────┘         │
+       │                   │                │
+       │                   └────────────────┘
+       ▼
+┌─────────────┐
+│    User     │
+└─────────────┘
+```
+
+### Before proceeding
+
+You need a working session 1 client before proceeding. Complete the regular task
+first, then revisit this one.
+
+You also need to deploy your own local AISHE server via Docker or Nix:
+
+- For Docker deployment, see the [prerequisites section above](#prerequisites)
+- For Nix deployment, see the [repository README.md](/README.md)
+
+This task involves modifying AISHE's server codebase. It's best to get familiar
+with it before making changes.
+
+If you're not entirely familiar with the concept of tool calling, check out
+[this brief introduction](https://medium.com/@yasir_siddique/tool-calling-for-llms-a-detailed-tutorial-a2b4d78633e2).
+
+Feel free to use AI agents to fulfill this task. Any LLM (gpt, claude, composer, grok, etc.) will work.
+
+### How to use AI to implement this task
+
+Below is a simple workflow you can use to implement this task in 40-50 minutes,
+even if you're unfamiliar with AI concepts.
+
+Pay attention to the *development process* itself:
+- We start by gathering needed context (information related to our topic).
+- Then we let AI narrow down our analysis into a targeted implementation.
+
+Using your favorite AI agent:
+
+1. **Ask** an AI agent to explain unknown concepts and AISHE's codebase to you:
+
+> What is a RAG pipeline and how is it used in AISHE?
+
+2. Have it make a **plan** to implement Wikipedia tool calls:
+
+> Come up with a step-by-step plan to give tools to Ollama so it can decide itself what information to look up
+
+3. Prompt AI agent to **implement** the produced plan:
+
+> Okay, now that we've refined the plan, implement it inside my codebase.
+> Then give me instructions on how to verify it works.
+
+4. **Debug** any issues:
+
+```bash
+# Prompt AISHE and inspect Ollama & server logs
+# Assert Ollama triggers an MCP request
+./your-cli "What is the capital of France?"
+```
+
+> Hey, when I ask AISHE about the capital of France, it responds with Paris but doesn't output Wikipedia sources?
+> Where did we make a mistake and how can we fix it?

--- a/workshop/session-2/README.md
+++ b/workshop/session-2/README.md
@@ -275,3 +275,140 @@ docker exec -it aishe-redis redis-cli --scan --pattern "aishe:question:*" | xarg
 docker exec -it aishe-redis redis-cli FLUSHDB
 ```
 
+---
+
+## STRETCH TASK: implement semantic caching
+
+AISHE + regular Redis cache = blazingly fast *exact* prompt text lookups
+
+AISHE + semantic Redis cache = still-extremely-fast *meaning-based* lookups
+
+To implement semantic caching you'll need to:
+
+1) Vectorize a prompt
+   > Text is split into tokens. An embedding model transforms
+   > these tokens into a list of numbers (an n-dimensional vector).
+
+2) Perform similarity search
+   > Compute how similar this prompt's meaning is to previous
+   > prompts in a vector database.
+
+3) If a similar one exists, reuse cached answer
+
+4) Otherwise cache this vector embedding and its answer
+
+```
+         ┌─────────────┐
+         │    User     │
+         │  question   │
+         └──────┬──────┘
+                │
+                ▼
+      ┌───────────────────┐
+      │   Embedding       │
+      │     model         │
+      │ (tokens → vector) │
+      └─────────┬─────────┘
+                │
+                │  n-dim vector
+                ▼
+    ┌───────────────────────┐
+    │   Redis vector DB     │
+    │  similarity search    │
+    │  over past prompts    │
+    └───────────┬───────────┘
+                │
+     ┌──────────┴──────────┐
+     │                     │
+  similar hit          no match
+  (score ≥ threshold)  (cache miss)
+     │                     │
+     ▼                     ▼
+┌─────────────┐     ┌─────────────┐
+│   Cached    │     │    AISHE    │
+│   answer    │     │   server    │
+│  (reused)   │     │ (full RAG)  │
+└──────┬──────┘     └──────┬──────┘
+       │                   │
+       │                   │  answer
+       │                   ▼
+       │            ┌─────────────┐
+       │            │ Store vector│
+       │            │  + answer   │
+       │            │  in Redis   │
+       │            └──────┬──────┘
+       │                   │
+       └─────────┬─────────┘
+                 │
+                 ▼
+          ┌─────────────┐
+          │    User     │
+          └─────────────┘
+```
+
+### Before proceeding
+
+You need a working session 2 client before proceeding. Complete the regular task
+first, then revisit this one.
+
+This task involves modifying your existing AISHE client. No server changes are necessary.
+
+For a more comprehensive overview of semantic caching, check out
+[this article](https://wso2.com/library/blogs/what-is-semantic-caching/).
+
+Again, you are free to use AI agents for this task.
+
+### How to use AI to implement this task
+
+Sometimes, you're barely familiar with the subject. You may not know how to
+store embeddings in Redis or compute semantic similarity.
+
+But you know what a working solution looks like. You have a well-defined task
+and don't know the implementation details.
+
+In these cases, you can *reverse the development process* (compared to stretch task 1):
+- We let AI implement our task with as many requirements as we know.
+- Later we study and refine the implementation piece-by-piece.
+
+1. Create a **detailed prompt** and have your AI agent implement the task outright:
+
+> I want you to implement semantic caching with Redis inside my Python client in
+> workshop/session-2/python/main.py.
+>
+> To do this you'll need to:
+> 1) Vectorize a prompt: text is split into tokens. An embedding model transforms
+>                        these tokens into a list of numbers (an n-dimensional vector)
+> 2) Perform similarity search: compute how similar this prompt's meaning is to
+>                               previous prompts in a vector database
+> 3) If a similar one exists, reuse cached answer
+> 4) Otherwise cache this vector embedding and its answer
+>
+> Use the LangCache model https://huggingface.co/redis/langcache-embed-v2. Show me
+> the simplest instructions to install it and set it up manually.
+>
+> Use my existing plain Redis OSS to store vector embeddings in whatever way you deem best.
+>
+> Make all code changes only in my main.py file. Optimize the code to be easy to read
+> for a software engineering student and adopt my personal style of coding.
+
+2. **Assert** it's working:
+
+```bash
+./your-cli "What is Redis?"
+```
+
+and
+
+```bash
+./your-cli "Explain Redis"
+```
+
+Should hit the cache and return the same response.
+
+3. Inspect, **study**, and question the implementation:
+
+> Hey, I'm curious: how does this code determine if two prompts are similar?
+
+4. **Refine** implementation chunk by chunk:
+
+> What similarity threshold would I need to set to match looser prompts like "Where is Redis used?"

--- a/workshop/session-3/README.md
+++ b/workshop/session-3/README.md
@@ -240,3 +240,12 @@ threshold = 0.90  # from 0.80
 - Limit cache size
 - Use local embedding models
 - Implement cache partitioning
+
+---
+
+## STRETCH TASK: use AI to implement stretch tasks
+
+Use your favorite AI agent to implement the following tasks:
+
+- [STRETCH TASK 1](/workshop/session-1/README.md#stretch-task-modern-aishe-architecture)
+- [STRETCH TASK 2](/workshop/session-2/README.md#stretch-task-implement-semantic-caching)


### PR DESCRIPTION
## Changes

Add STRETCH tasks from presentation slides inside session 1 & 2 READMEs. Tasks are:

- session 1: Provide Wikipedia tools to AISHE
- session 2: Implement semantic caching

Both tasks have additional guidelines on how they can be implemented via agentic AI (i.e. "the third session's STRETCH task").

## Rationale

Last time we had advanced folks finish some sessions in minutes (especially session 2, which can easily be done within 5-10 minutes). Those same folks also requested going into more technical depth on AI concepts in our feedback form.

Plan is to allow advanced folks to go through the workshop at their own pace and tackle these STRETCH tasks on-site. Rest of the group follows our 3-session workshop.

---

**Tested with:** Used `gpt-5.2` in `ask` & `agent` mode (Cursor IDE) to implement both tasks with given agentic AI guidelines.

PS: fixed a bug where `ollama` always responded with degraded health status, even when passing the health check.