### PR TITLE
fix(go): pass context to functions

### DIFF
--- a/workshop/session-2/go/solution/main.go
+++ b/workshop/session-2/go/solution/main.go
@@ -47,8 +47,7 @@ func getCacheKey(question string) string {
 }
 
 // getFromCache retrieves cached response for a question
-func getFromCache(client *redis.Client, question string) (*Response, error) {
-	ctx := context.Background()
+func getFromCache(ctx context.Context, client *redis.Client, question string) (*Response, error) {
 	cacheKey := getCacheKey(question)
 
 	cachedData, err := client.Get(ctx, cacheKey).Result()
@@ -65,8 +64,7 @@ func getFromCache(client *redis.Client, question string) (*Response, error) {
 }
 
 // saveToCache saves response to cache
-func saveToCache(client *redis.Client, question string, response *Response) error {
-	ctx := context.Background()
+func saveToCache(ctx context.Context, client *redis.Client, question string, response *Response) error {
 	cacheKey := getCacheKey(question)
 
 	jsonData, err := json.Marshal(response)
@@ -125,7 +123,7 @@ func main() {
 	var data *Response
 	var fromCache bool
 
-	cachedResponse, err := getFromCache(rdb, question)
+	cachedResponse, err := getFromCache(ctx, rdb, question)
 	if err == nil && cachedResponse != nil {
 		fmt.Println("✓ Found in cache! (no API call needed)\n")
 		data = cachedResponse
@@ -181,7 +179,7 @@ func main() {
 		}
 
 		// Save to cache for future use
-		if err := saveToCache(rdb, question, data); err != nil {
+		if err := saveToCache(ctx, rdb, question, data); err != nil {
 			fmt.Printf("Warning: Error saving to cache: %v\n", err)
 		} else {
 			fmt.Println("✓ Response saved to cache\n")
@@ -225,4 +223,3 @@ func main() {
 	fmt.Printf("Execution time: %.2f seconds\n", executionTime)
 	fmt.Println(strings.Repeat("=", 70))
 }
-

--- a/workshop/session-2/go/starter/main.go
+++ b/workshop/session-2/go/starter/main.go
@@ -51,7 +51,7 @@ func getCacheKey(question string) string {
 // 2. Query Redis for the cached value
 // 3. Handle cache miss vs. other errors appropriately
 // 4. Parse and return the cached JSON response
-func getFromCache(client *redis.Client, question string) (*Response, error) {
+func getFromCache(ctx context.Context, client *redis.Client, question string) (*Response, error) {
 	panic("not implemented")
 }
 
@@ -62,7 +62,7 @@ func getFromCache(client *redis.Client, question string) (*Response, error) {
 // 2. Serialize the response to JSON
 // 3. Save to Redis with an appropriate expiration time
 // 4. Handle any errors from the operation
-func saveToCache(client *redis.Client, question string, response *Response) error {
+func saveToCache(ctx context.Context, client *redis.Client, question string, response *Response) error {
 	panic("not implemented")
 }
 
@@ -113,7 +113,7 @@ func main() {
 	var data *Response
 	var fromCache bool
 
-	cachedResponse, err := getFromCache(rdb, question)
+	cachedResponse, err := getFromCache(ctx, rdb, question)
 	if err != nil {
 		fmt.Printf("Warning: Error reading from cache: %v\n", err)
 	}
@@ -172,7 +172,7 @@ func main() {
 		}
 
 		// Save to cache for future use
-		if err := saveToCache(rdb, question, data); err != nil {
+		if err := saveToCache(ctx, rdb, question, data); err != nil {
 			fmt.Printf("Warning: Error saving to cache: %v\n", err)
 		} else {
 			fmt.Println("✓ Response saved to cache\n")


### PR DESCRIPTION
Enables cancellation, timeouts and follow industry best practices for Go.

```
Do not store Contexts inside a struct type; instead, pass a Context explicitly to each function that needs it.
This is discussed further in https://go.dev/blog/context-and-structs. The Context should be the first parameter, typically named ctx:
```

ref: https://pkg.go.dev/context